### PR TITLE
Added abstract splitter example

### DIFF
--- a/preprocessing/split_abstracts.py
+++ b/preprocessing/split_abstracts.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import re
+import pandas as pd
+
+data = pd.read_csv('nips-data/papers.csv')
+
+# Data cleaners
+# Add lines around chapter titles
+chapter_matcher = re.compile(r'(^[A-Z1-9][*\.A-Z \s]*)$', flags=re.MULTILINE)
+# Replace newlines between words with blanks.
+newline_matcher = re.compile(r'(?<=[&{}\;\"\'\w\(\)\.\,\?\-\/\\<>])\n(?=[&{}\;\"\'\w\(\)\.\,\?\-\/\\<>])')
+# Match abstracts in two ways: either a paragraph before the introduction, or the paragraph after "abstract"
+abstract_matcher = re.compile(
+    r'([+{}=*&\[\]<>\;\:\"\'\w \(\)\.\,\?\-\/\\]*\s*\d+\s*introduction)|(a[bm][es]?[tl]rac[tf][\s-]*[+{}*=&\[\]\;\:<>\"\'\w \(\)\.\,\?\-\/\\]*)',
+    flags=re.IGNORECASE)
+# Remove before and including "abstract"
+abstract_remover = re.compile(r'^.*(?i:a[bm][es]?[tl]rac[tf])[-:\s]*?(?=[A-Z])')
+
+
+def cleaner(text):
+    try:
+        text = re.sub(chapter_matcher, r'\n\1\n', text)
+        text = re.sub(newline_matcher, r' ', text)
+        text = re.search(abstract_matcher, text).group(0)
+        text = re.sub(abstract_remover, r'', text)
+        return text[:text.rfind('.') + 1]
+    except AttributeError:
+        return ''
+
+data.abstract = data.paper_text.apply(cleaner)


### PR DESCRIPTION
I did some regex magic to try and extract abstracts from the paper_text attributes.
I checked some of the papers and it works pretty accurately. If nothing matches or the data is gibberish then the abstract will be an empty string ''.

Note that it is possible it might return more/less text than the actual abstract (without any way to know apart from manually checking).